### PR TITLE
generalize conditional compile for update_pmtu

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,17 @@ CONFIG_MODULE_SIG=n
 MODULE_NAME = gtp5g
 obj-m := $(MODULE_NAME).o
 
+KMAJMIN=$(grep -o '[0-9][0-9][0-9][0-9]*' /usr/include/linux/version.h)
+
+##
+## Handle specific version of Ubuntu modified kernels as well as generic 4.19.93 and above
+## 4.19.93 == (4 << 16) + (19 << 8) + 93 == 267101
+
+UPDATE_PMTU_BOOL := $(if KVERSION=='4.15.0-109-generic', 1, $(if $KMAJMIN >= 267101, 1, 0))
+
+#CFLAGS-y := -DUPDATE_PMTU_BOOL="$(UPDATE_PMTU_BOOL)"
+ccflags-y := -DUPDATE_PMTU_BOOL="$(UPDATE_PMTU_BOOL)"
+
 all:
 	make -C $(INCLUDE_DIR) M=$(PWD) modules
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 PWD := $(shell pwd) 
-KVERSION := $(shell uname -r)
+KVERSION=$(shell uname -r)
 INCLUDE_DIR = /usr/src/linux-headers-$(KVERSION)/
 
 CONFIG_MODULE_SIG=n
 MODULE_NAME = gtp5g
 obj-m := $(MODULE_NAME).o
+
+#
+# return 'yes' or 'no' if this is an Ubuntu kernel that supports the additional argument
+#
+KVERSION_UBUNTU := $(shell uname -r | awk -F'-' '{if ($$2 >= 109) {print "yes"} else {print "no"}}')
 
 KMAJMIN=$(grep -o '[0-9][0-9][0-9][0-9]*' /usr/include/linux/version.h)
 
@@ -12,7 +17,7 @@ KMAJMIN=$(grep -o '[0-9][0-9][0-9][0-9]*' /usr/include/linux/version.h)
 ## Handle specific version of Ubuntu modified kernels as well as generic 4.19.93 and above
 ## 4.19.93 == (4 << 16) + (19 << 8) + 93 == 267101
 
-UPDATE_PMTU_BOOL := $(if KVERSION=='4.15.0-109-generic', 1, $(if $KMAJMIN >= 267101, 1, 0))
+UPDATE_PMTU_BOOL := $(if KVERSION_UBUNTU=='yes', 1, $(if $KMAJMIN >= 267101, 1, 0))
 
 #CFLAGS-y := -DUPDATE_PMTU_BOOL="$(UPDATE_PMTU_BOOL)"
 ccflags-y := -DUPDATE_PMTU_BOOL="$(UPDATE_PMTU_BOOL)"

--- a/gtp5g.c
+++ b/gtp5g.c
@@ -764,7 +764,7 @@ static struct rtable *ip4_find_route(struct sk_buff *skb, struct iphdr *iph,
 		mtu = dst_mtu(&rt->dst);
 	}
 	
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+#if UPDATE_PMTU_BOOL
 	rt->dst.ops->update_pmtu(&rt->dst, NULL, skb, mtu, false);
 #else
 	rt->dst.ops->update_pmtu(&rt->dst, NULL, skb, mtu);


### PR DESCRIPTION
The following change generalizes the conditional compilation mechanism for the update_pmtu conditional compile. The extra argument was introduced in Linux 4.19.93 but common distributions such as Ubuntu 18.04.04 backported that change. This change to the makefile allows checks for specific kernel versions based on `uname` and also includes the check for numeric kernels >= 4.19.93.

The module compiles and insmods on Ubuntu 18.04.4 but I don't know if it works because no regression testing method (yet).