### PR TITLE
set a default MTU for the tunnel device

### DIFF
--- a/gtp5g.c
+++ b/gtp5g.c
@@ -1148,6 +1148,10 @@ static void gtp5g_link_setup(struct net_device *dev)
 
     dev->hard_header_len = 0;
     dev->addr_len = 0;
+    dev->mtu = ETH_DATA_LEN -
+	    (sizeof(struct iphdr) +
+	     sizeof(struct udphdr) +
+	     sizeof(struct gtp1_header));
 
     /* Zero header length. */
     dev->type = ARPHRD_NONE;


### PR DESCRIPTION
The current implementation creates the tunnel device with an MTU of 0 which is not optimal. The free5gs-upfd also does not set the MTU so this leads to problems. 